### PR TITLE
Small improvement: Make from_c_parts only visible inside crate

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -127,14 +127,17 @@ impl Message {
     ///
     /// * `topic` The topic on which the message is published.
     /// * `msg` The message struct from the C library
-    pub fn from_c_parts(topic: CString, cmsg: &ffi::MQTTAsync_message) -> Self {
+    /// 
+    /// # Safety
+    /// 
+    /// Caller must make sure that cmsg is valid 
+    pub(crate) unsafe fn from_c_parts(topic: CString, cmsg: &ffi::MQTTAsync_message) -> Self {
         let len = cmsg.payloadlen as usize;
 
         let payload = if cmsg.payload.is_null() {
             Vec::new()
-        }
-        else {
-            unsafe { slice::from_raw_parts(cmsg.payload as *mut u8, len) }.to_vec()
+        } else {
+            slice::from_raw_parts(cmsg.payload as *mut u8, len).to_vec()
         };
 
         let data = MessageData {


### PR DESCRIPTION
Hi, 

I made a (very) small PR to keep the from_c_parts private to the crate. The functions is very unsafe since it is possible to construct MQTTAsync_message from safe rust which will cause UB eg. set payload to point to unitialized memory. 

Cheers, 

Jan 