### PR TITLE
fix build with gcc 15

### DIFF
--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -285,6 +285,7 @@ mod build {
 
         let mut cmk_cfg = cmake::Config::new("paho.mqtt.c/");
         cmk_cfg
+            .define("CMAKE_C_STANDARD", "11")
             .define("PAHO_BUILD_SHARED", "off")
             .define("PAHO_BUILD_STATIC", "on")
             .define("PAHO_ENABLE_TESTING", "off")


### PR DESCRIPTION
gcc 15 uses c23 as default. paho.mqtt.c is written with c11