### PR TITLE
Update crossbeam-channel and fix double free on Drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2"
 futures = "0.3"
 futures-timer = "3.0"
 async-channel = "1.6"
-crossbeam-channel = "0.5"
+crossbeam-channel = "0.5.15"
 log = "0.4"
 thiserror = "1.0"
 


### PR DESCRIPTION
Cargo audit gives this:

```
"id": "RUSTSEC-2025-0024",
"package": "crossbeam-channel",
"title": "crossbeam-channel: double free on Drop",
"description": "The internal `Channel` type's `Drop` method has a race\nwhich could, in some circumstances, lead to a double-free.\nThis could result in memory corruption.\n\nQuoting from the\n[upstream description in merge request \\#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187#issue-2980761131):\n\n> The problem lies in the fact that `dicard_all_messages` contained two paths that could lead to `head.block` being read but only one of them would swap the value. This meant that `dicard_all_messages` could end up observing a non-null block pointer (and therefore attempting to free it) without setting `head.block` to null. This would then lead to `Channel::drop` making a second attempt at dropping the same pointer.\n\nThe bug was introduced while fixing a memory leak, in\nupstream [MR \\#1084](https://github.com/crossbeam-rs/crossbeam/pull/1084),\nfirst published in 0.5.12.\n\nThe fix is in\nupstream [MR \\#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187)\nand has been published in 0.5.15",
```