### PR TITLE
Fix async MQTT5 error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ lazy_static = "1.4"
 futures-util = "0.3"
 ctrlc = "3.2"
 smol = "2.0"
+test-case = "3.3.1"
 
 [[example]]
 name = "tokio_event_subscribe_v5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -79,6 +79,7 @@ impl TryFrom<u8> for ConnectReturnCode {
             3 => Ok(ServerUnavailable),
             4 => Ok(BadUserNameOrPassword),
             5 => Ok(NotAuthorized),
+            c if c >= 128 => Err(Error::ReasonCode(ReasonCode::from(c as u32))),
             _ => Err(Error::Failure),
         }
     }
@@ -236,6 +237,9 @@ impl From<i32> for Error {
             ffi::MQTTASYNC_0_LEN_WILL_TOPIC => ZeroLenWillTopic,
             ffi::MQTTASYNC_COMMAND_IGNORED => CommandIgnored,
             ffi::MQTTASYNC_MAX_BUFFERED => MaxBufferedZero,
+            code if code >= crate::reason_code::ReasonCode::UnspecifiedError as i32 => {
+                Error::ReasonCode(crate::reason_code::ReasonCode::from(code as u32))
+            }
             _ => Failure,
         }
     }
@@ -262,6 +266,11 @@ impl From<(i32, &str)> for Error {
                 Err(err) => err,
             },
             (rc, "socket error") => SocketError(rc),
+            (reason_code, _)
+                if reason_code >= crate::reason_code::ReasonCode::UnspecifiedError as i32 =>
+            {
+                Error::ReasonCode(crate::reason_code::ReasonCode::from(reason_code as u32))
+            }
             _ => Failure,
         }
     }
@@ -301,7 +310,7 @@ impl From<Error> for io::Error {
         match err {
             Error::Io(e) => e,
             Error::Timeout => io::Error::new(io::ErrorKind::TimedOut, err),
-            _ => io::Error::other(err),
+            _ => io::Error::new(io::ErrorKind::Other, err),
         }
     }
 }
@@ -352,15 +361,23 @@ where
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_error_from_rc() {
-        let err = Error::from(ffi::MQTTASYNC_BAD_QOS);
-        assert!(matches!(err, Error::BadQos));
+    #[test_case::test_case(ffi::MQTTASYNC_FAILURE => matches Error::Failure)]
+    #[test_case::test_case(ffi::MQTTASYNC_BAD_QOS => matches Error::BadQos)]
+    #[test_case::test_case(127 => matches Error::Failure)]
+    #[test_case::test_case(128 => matches Error::ReasonCode(ReasonCode::UnspecifiedError))]
+    #[test_case::test_case(135 => matches Error::ReasonCode(ReasonCode::NotAuthorized))]
+    fn test_error_from_rc(code: i32) -> Error {
+        Error::from(code)
     }
 
-    #[test]
-    fn test_error_from_msg() {
-        let err = Error::from((ffi::MQTTASYNC_FAILURE, "TCP connect timeout"));
-        assert!(matches!(err, Error::TcpConnectTimeout));
+    #[test_case::test_case(ffi::MQTTASYNC_FAILURE, "unspecified error" => matches Error::Failure)]
+    #[test_case::test_case(ffi::MQTTASYNC_FAILURE, "TCP connect timeout" => matches Error::TcpConnectTimeout)]
+    #[test_case::test_case(-34, "socket error" => matches Error::SocketError(-34))]
+    #[test_case::test_case(127, "socket error" => matches Error::SocketError(127))]
+    #[test_case::test_case(127, "any text" => matches Error::Failure)]
+    #[test_case::test_case(128, "ignored message" => matches Error::ReasonCode(ReasonCode::UnspecifiedError))]
+    #[test_case::test_case(135, "ignored message" => matches Error::ReasonCode(ReasonCode::NotAuthorized))]
+    fn test_error_from_rc_and_msg(code: i32, msg: &str) -> Error {
+        Error::from((code, msg))
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -293,7 +293,26 @@ impl TokenInner {
 
         if let Some(rsp) = rsp.as_ref() {
             msgid = rsp.token as u16;
-            rc = if rsp.code == 0 { -1 } else { rsp.code as i32 };
+            rc = if rsp.reasonCode > 0 {
+                debug!(
+                    "Token w ID {} failed with reason code: {}",
+                    msgid, rsp.reasonCode
+                );
+                rsp.reasonCode as i32
+            }
+            // it is unclear if the C library will ever return a success code here, but if it does,
+            // we should treat it as a failure with no reason code.
+            else if rsp.code == ffi::MQTTASYNC_SUCCESS as i32 {
+                debug!(
+                    "Token w ID {} failed with no reason code, but success return code: {}",
+                    msgid, rsp.code
+                );
+                ffi::MQTTASYNC_FAILURE
+            }
+            else {
+                debug!("Token w ID {} failed with return code: {}", msgid, rsp.code);
+                rsp.code as i32
+            };
 
             if !rsp.message.is_null() {
                 if let Ok(cmsg) = CStr::from_ptr(rsp.message).to_str() {
@@ -302,8 +321,6 @@ impl TokenInner {
                 }
             }
         }
-
-        debug!("Token w ID {} failed with code: {}", msgid, rc);
 
         // Fire off any user callbacks
 
@@ -320,17 +337,7 @@ impl TokenInner {
         // Signal completion of the token
 
         let mut data = tok.inner.lock.lock().unwrap();
-        data.res = Some(if rc == 0 {
-            if let Some(rsp) = rsp.as_ref() {
-                Ok(ServerResponse::from_failure5(rsp))
-            }
-            else {
-                Ok(ServerResponse::default())
-            }
-        }
-        else {
-            Err(Error::from((rc, err_msg)))
-        });
+        data.res = Some(Err(Error::from((rc, err_msg))));
 
         // If this is none, it means that no one is waiting on
         // the future yet, so we don't need to wake it.


### PR DESCRIPTION
The Paho C-library has been fixed in 1.3.15 to properly put MQTT5 reason codes into the corresponding error structure. The crate's MQTT5 error handling code has been adapted to pass these codes to the client, wrapped in a ReasonCode error.

This allows client code to implement error handling code that is specific to the problem at hand, instead of having to rely on generic error handling that may not be able to distinguish between different MQTT5 errors.

Fixes #244