### PR TITLE
Add OpenSSL install path to `CMAKE_PREFIX_PATH`

### DIFF
--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -304,7 +304,8 @@ mod build {
         }
 
         if let Some(ssl_dir) = openssl_root_dir() {
-            cmk_cfg.define("OPENSSL_ROOT_DIR", ssl_dir);
+            cmk_cfg.define("OPENSSL_ROOT_DIR", &ssl_dir);
+            cmk_cfg.define("CMAKE_PREFIX_PATH", &ssl_dir);
         }
 
         // 'cmk_install_dir' is a PathBuf to the cmake install directory


### PR DESCRIPTION
Fixes #252

The OpenSSL install path has been passed to CMake via the `OPENSSL_ROOT_DIR` cache variable. However, in some cross compilation environments such as cross-rs the `OPENSSL_ROOT_DIR` path (and all other search paths of `find_file`, `find_library` etc.) get prepended with `CMAKE_FIND_ROOT_PATH`. Thus finding the OpenSSL artifacts fails.

The cross-rs environment does add the `CMAKE_PREFIX_PATH` to the `CMAKE_FIND_ROOT_PATH` [1] so adding the OpenSSL install path to the `CMAKE_PREFIX_PATH` fixes the issue.

[1] https://github.com/cross-rs/cross/blob/588b3c99db52b5a9c5906fab96cfadcf1bde7863/docker/toolchain.cmake#L43